### PR TITLE
Update for Jessie

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ and on top of that:
    - `Date`_: Support Date field in custom content types.
 
 - SSL support out of the box.
-- `PHPMyAdmin`_ administration frontend for MySQL (listening on port
+- `Adminer`_ administration frontend for MySQL (listening on port
   12322 - uses SSL).
 - Postfix MTA (bound to localhost) to allow sending of email (e.g.,
   password recovery).
@@ -63,7 +63,7 @@ and on top of that:
 Credentials *(passwords set at first boot)*
 -------------------------------------------
 
--  Webmin, SSH, MySQL, phpMyAdmin: username **root**
+-  Webmin, SSH, MySQL, Adminer: username **root**
 -  Drupal 7: username **admin**
 
 .. _Drupal: http://drupal.org
@@ -91,4 +91,4 @@ Credentials *(passwords set at first boot)*
 .. _Email: http://drupal.org/project/email
 .. _Link: http://drupal.org/project/link
 .. _Date: http://drupal.org/project/date
-.. _PHPMyAdmin: http://www.phpmyadmin.net
+.. _Adminer: http://www.adminer.org

--- a/changelog
+++ b/changelog
@@ -1,3 +1,16 @@
+turnkey-drupal7-14.0 (1) turnkey; urgency=low                                                         
+
+  * Drupal7:
+
+    - Latest 7.x version of Drush is now installed via composer at build time.
+    - Latest version of Drupal7 is installed via Drush.
+    - Latest versions of modules are now installed via Drush.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 03 Jul 2015 13:55:12 +1000
+
 turnkey-drupal7-13.0 (1) turnkey; urgency=low
 
   * Drupal7:

--- a/conf.d/main
+++ b/conf.d/main
@@ -16,9 +16,16 @@ WEBROOT=/var/www/drupal7
 # increase php cli memory limit (for drush)
 sed -i "s|^memory_limit.*|memory_limit = 64M|" /etc/php5/cli/php.ini
 
-# install drush and configure
-pear channel-discover pear.drush.org
-pear install drush/drush
+# install composer
+curl -sS https://getcomposer.org/installer | php
+mv composer.phar /usr/local/bin/composer
+
+# install drush latest stable (7.x)
+git clone -b 7.x --depth 1 https://github.com/drush-ops/drush.git $SRC/drush
+cd $SRC/drush
+composer install
+ln -s $SRC/drush/drush /usr/local/bin/drush
+ln -s $SRC/drush/drush.complete.sh /etc/bash_completion.d/drush
 
 mkdir -p /etc/drush
 cat > /etc/drush/drushrc.php << EOF

--- a/plan/main
+++ b/plan/main
@@ -1,7 +1,7 @@
 #include <turnkey/base>
 #include <turnkey/lamp>
 
-php-pear            /* used for drush */
+php5-readline
 
 php5-gd
 php5-curl           /* dependency of drupal module simpletest */


### PR DESCRIPTION
Very little has changed; just install Drush via composer now (as recommended by upstream).
