### PR TITLE
changed references to drush path consistent with 22a49fd

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -91,9 +91,9 @@ cat >$CRON_DRUPAL<<EOF
 # Trigger drush cron
 # Alternatively Drupal's poor mans cron: sites/default/settings.php
 
-[ -x /usr/bin/drush ] || exit 0
+[ -x /usr/local/bin/drush ] || exit 0
 
-su www-data -c "/usr/bin/drush --quiet cron"
+su www-data -c "/usr/local/bin/drush --quiet cron"
 EOF
 chmod +x $CRON_DRUPAL
 

--- a/overlay/usr/lib/inithooks/bin/drupal7.py
+++ b/overlay/usr/lib/inithooks/bin/drupal7.py
@@ -57,9 +57,9 @@ def main():
     m = MySQL()
     m.execute('UPDATE drupal7.users SET mail=\"%s\" WHERE name=\"admin\";' % email)
     m.execute('UPDATE drupal7.users SET init=\"%s\" WHERE name=\"admin\";' % email)
-    system("/usr/bin/drush variable-set site_mail %s" % email)
-    system("/usr/bin/drush variable-set update_notify_emails %s" % email)
-    system("/usr/bin/drush user-password admin --password='%s'" % password)
+    system("/usr/local/bin/drush variable-set site_mail %s" % email)
+    system("/usr/local/bin/drush variable-set update_notify_emails %s" % email)
+    system("/usr/local/bin/drush user-password admin --password='%s'" % password)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When Jeremy changed to install drush using composer, the default path changed from /usr/bin/drush to /usr/local/bin/drush.  This fix changes several references to the old path in conf.d/main and in the firstboot overlays.
