### PR TITLE
Composer cleanup

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -21,10 +21,6 @@ WEBROOT=/var/www/drupal7
 sed -i "s|^memory_limit.*|memory_limit = 76M|" /etc/php5/cli/php.ini
 sed -i "s|^memory_limit.*|memory_limit = 64M|" /etc/php5/apache2/php.ini
 
-# install composer
-curl -sS https://getcomposer.org/installer | php
-mv composer.phar /usr/local/bin/composer
-
 # install drush latest 7.x
 git clone -b 7.x --depth 1 https://github.com/drush-ops/drush.git $SRC/drush
 cd $SRC/drush


### PR DESCRIPTION
removing old way of installing composer

part of https://github.com/turnkeylinux/tracker/issues/527

relies on https://github.com/turnkeylinux/common/pull/59
