### PR TITLE
Make 20regen-drupal7-secrets more robust and cleaner.

### DIFF
--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-drupal7-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-drupal7-secrets
@@ -6,9 +6,9 @@
 CONF=/var/www/drupal7/sites/default/settings.php
 
 SALT=$(mcookie)
-sed -i "s|^\$drupal_hash_salt = \(.*\)|\$drupal_hash_salt = '$SALT';|" $CONF
+sed -i "s|^\$drupal_hash_salt = .*|\$drupal_hash_salt = '$SALT';|" $CONF
 
 PASSWORD=$(mcookie)
-sed -i "s|^    'password'\(.*\)|    'password' => '$PASSWORD',|" $CONF
+sed -i "s|^\( *\)'password'.*|\1'password' => '$PASSWORD',|" $CONF
 $INITHOOKS_PATH/bin/mysqlconf.py --user=drupal7 --pass="$PASSWORD"
 


### PR DESCRIPTION
part of https://github.com/turnkeylinux/tracker/issues/1647