### PR TITLE
Install specific ckeditor module version

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -92,12 +92,14 @@ chmod 640 $CONF
 chown -R $USER:$USER $WEBROOT/sites/default/files
 
 # download, install and enable modules
+# Install specific "recommended version" of ckeditor
+# - otherwise asked interactively
 turnkey-drush dl --default-major=7 \
 	admin_menu \
 	admin_views \
 	advanced_help \
 	backup_migrate \
-	ckeditor \
+	ckeditor-7.x-1.23 \
 	colorbox \
 	ctools \
 	entity \


### PR DESCRIPTION
Last minute tweak to Drupal 7 v18.1 build. If specific version of ckeditor is not explictly noted, it asks for which version. Current choices are: security, recommend or dev. This installs current "recommended".

Ultimately, this probably shouldn't be a hardcoded version, but it will deal for now.

